### PR TITLE
Hide django key

### DIFF
--- a/InnoClubs/InnoClubs/settings.py
+++ b/InnoClubs/InnoClubs/settings.py
@@ -22,7 +22,8 @@ sys.path.insert(0, os.path.join(PROJECT_ROOT, 'apps'))
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '0s&^vx6d4de9r+4-q$!!429kx=8)o_oecqzqjzatthzd7!1-0f'
+SECRET_KEY = os.environ['FSE_DJANGO_KEY']
+print(SECRET_KEY)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # InnoClubs
 InnoClubs project for Fundamentals of Software Engineering course (Fall 2020, group 02) at Innopolis University
+
+# Get ready for launch
+Before starting the server you need to add django key to your environmental variables.
+
+## Linux
+* Open `~/.bashrc`
+* Add command `export FSE_DJANGO_KEY='(your_key)'` with actual key instead of `(your_key)`
+* Restart the system or write bash command `source ~/.bashrc` to apply changes
+
+## Windows
+* Open properties by right-clicking **Computer** and choosing corresponding option or click on **System** in Windows Control Panel
+* Switch to **Advanced** tab
+* Press **Environment Variables...** button
+* Use **New** to create a new variable with name `FSE_DJANGO_KEY` and corresponding value
+* Click **Apply** and **OK** to save changes


### PR DESCRIPTION
Change settings to get the key from environmental variables instead of
it being explicitly written in the code